### PR TITLE
rename forCelsius() to fromCelsius()

### DIFF
--- a/src/Temperature.php
+++ b/src/Temperature.php
@@ -6,7 +6,7 @@ class Temperature
 {
     private float $celsius;
 
-    public static function forCelsius(float $celsius): self
+    public static function fromCelsius(float $celsius): self
     {
         return new static($celsius);
     }

--- a/tests/TemperatureTest.php
+++ b/tests/TemperatureTest.php
@@ -10,7 +10,7 @@ class TemperatureTest extends TestCase
     /** @test */
     public function it_can_convert_celsius_to_fahrenheit()
     {
-        $fahrenheit = Temperature::forCelsius(100)->toFahrenheit();
+        $fahrenheit = Temperature::fromCelsius(100)->toFahrenheit();
 
         $this->assertEquals(212, $fahrenheit);
     }


### PR DESCRIPTION
Despite of being a BC break, in order to keep consistency, i think we should use fromCelsius() instead of forCelsius(), just like we have fromKilograms() instead of forKilograms().